### PR TITLE
feat(http, express): introduce fully pluggable http adapter architecture and Express integration with @glandjs/core

### DIFF
--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,0 +1,24 @@
+import { Controller, Module } from '@glandjs/common'
+import { Get } from '@glandjs/http'
+import { GlandFactory } from '@glandjs/core'
+import { ExpressBroker, type ExpressContext } from '@glandjs/express'
+
+@Controller('/')
+class UserController {
+  @Get()
+  index(ctx: ExpressContext) {
+    ctx.res.send('Hello World')
+  }
+}
+
+@Module({
+  controllers: [UserController],
+})
+class AppModule {}
+
+async function bootstrap() {
+  const app = await GlandFactory.create(AppModule)
+  const express = app.connectTo(ExpressBroker)
+  express.listen(3000)
+}
+bootstrap()

--- a/packages/express/express-adapter.ts
+++ b/packages/express/express-adapter.ts
@@ -1,0 +1,191 @@
+import {
+  HttpContext,
+  HttpServerAdapter,
+  ServerFactory,
+  type HttpApplicationOptions,
+} from '@glandjs/http'
+import type { CorsConfig } from '@glandjs/http/types'
+import { isNil, isObject, isString } from '@medishn/toolkit'
+import express, { type Application, type Request, type Response } from 'express'
+import { normalizePath } from '@glandjs/common'
+import cors from 'cors'
+import { pipeline } from 'node:stream'
+import { Server } from 'net'
+export class ExpressAdapter extends HttpServerAdapter<
+  Server,
+  Application,
+  Request,
+  Response
+> {
+  constructor() {
+    super(express())
+    this.instance.use((req: Request, res: Response, next: Function) => {
+      const ctx = new HttpContext(this.events, req, res)
+      ;(req as any).ctx = ctx
+      next()
+    })
+  }
+
+  public initialize(): Promise<void> | void {
+    this.logger.info('Initializing Express adapter')
+    this.events.on('options', (options) => {
+      console.log('OPTIONS:', options)
+    })
+  }
+  public listen(
+    port: number | string,
+    hostname: string = 'localhost',
+    message?: string
+  ) {
+    try {
+      const parsedPort = isString(port) ? parseInt(port, 10) : port
+
+      const options = this.events.request<HttpApplicationOptions>(
+        'options',
+        {},
+        'first'
+      )
+
+      const defaultMessage = `Server listening on ${hostname}:${parsedPort}`
+      this.logger.info(message ?? defaultMessage)
+      this.server = ServerFactory.create(options, this.instance)
+      this.server.listen(parsedPort, hostname)
+    } catch (error) {
+      this.handleError(error, 'Failed to start Express server')
+    }
+  }
+
+  public async close(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.server) {
+        resolve()
+        return
+      }
+
+      this.server.close((err) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        this.logger.info('Express server closed')
+        resolve()
+      })
+    })
+  }
+
+  public reply(response: any, body: any, statusCode?: number): any {
+    if (statusCode) {
+      response.status(statusCode)
+    }
+
+    if (isNil(body)) {
+      return response.send()
+    }
+
+    if (body && body.getStream && typeof body.getStream === 'function') {
+      const streamHeaders = body.getHeaders ? body.getHeaders() : {}
+
+      if (
+        response.getHeader('Content-Type') === undefined &&
+        streamHeaders.type
+      ) {
+        response.setHeader('Content-Type', streamHeaders.type)
+      }
+
+      return pipeline(
+        body.getStream().once('error', (err: Error) => {
+          response.status(500).end()
+          this.logger.error(err)
+        }),
+        response,
+        (err: any) => {
+          if (err) {
+            this.logger.error(err)
+          }
+        }
+      )
+    }
+
+    return isObject(body) ? response.json(body) : response.send(String(body))
+  }
+
+  public use(...args: any[]): any {
+    const wrapped = args.map((arg) => {
+      if (typeof arg !== 'function') return arg
+
+      if (arg.length === 2 || arg.length === 3) {
+        return function (req: Request, res: Response, next: Function) {
+          const ctx = (req as any).ctx
+          if (!ctx) return next(new Error('No context found in middleware'))
+
+          try {
+            arg(ctx, next)
+          } catch (err) {
+            next(err)
+          }
+        }
+      }
+
+      return arg
+    })
+
+    return this.instance.use(...wrapped)
+  }
+  public registerRoute(method: string, path: string, action: Function): void {
+    const normalizedPath = normalizePath(path)
+
+    this.instance[method.toLowerCase()](
+      normalizedPath,
+      async (req: Request, res: Response, next: Function) => {
+        try {
+          const ctx = (req as any).ctx
+
+          const result = await action(ctx)
+
+          if (result !== undefined && !res.headersSent) {
+            this.reply(res, result)
+          }
+        } catch (error) {
+          next(error)
+        }
+      }
+    )
+  }
+
+  public enableCors(options: CorsConfig): void {
+    this.use(cors(options as any))
+  }
+
+  public set(key: string, value: any): this {
+    this.instance.set(key, value)
+    return this
+  }
+
+  public engine(ext: string, engine: any): this {
+    this.instance.engine(ext, engine)
+    return this
+  }
+
+  public setViewEngine(engine: string): this {
+    return this.set('view engine', engine)
+  }
+
+  public setBaseViewsDir(path: string | string[]): this {
+    return this.set('views', path)
+  }
+
+  public setGlobalPrefix(prefix: string): void {
+    if (!prefix.startsWith('/')) {
+      prefix = `/${prefix}`
+    }
+
+    const router = express.Router()
+    this.instance.use(prefix, router)
+
+    this.logger.info(`Global prefix set to: ${prefix}`)
+  }
+  public useStaticAssets(path: string): void {
+    this.instance.use(express.static(path))
+    this.logger.info(`Static asset directory registered: ${path}`)
+  }
+}

--- a/packages/express/express-broker.ts
+++ b/packages/express/express-broker.ts
@@ -1,0 +1,11 @@
+import { HttpBroker, type HttpApplicationOptions } from '@glandjs/http'
+import { ExpressCore } from './express-core'
+
+export class ExpressBroker extends HttpBroker<
+  ExpressCore,
+  HttpApplicationOptions
+> {
+  constructor(options?: HttpApplicationOptions) {
+    super(new ExpressCore(options), options)
+  }
+}

--- a/packages/express/express-context.ts
+++ b/packages/express/express-context.ts
@@ -1,0 +1,4 @@
+import { HttpContext } from '@glandjs/http'
+import type { Request, Response } from 'express'
+
+export class ExpressContext extends HttpContext<Request, Response> {}

--- a/packages/express/express-core.ts
+++ b/packages/express/express-core.ts
@@ -1,0 +1,14 @@
+import { HttpCore, type HttpApplicationOptions } from '@glandjs/http'
+import { ExpressAdapter } from './express-adapter'
+import type { Application, Request, Response } from 'express'
+import type { Server } from 'net'
+export class ExpressCore extends HttpCore<
+  Server,
+  Application,
+  Request,
+  Response
+> {
+  constructor(options?: HttpApplicationOptions) {
+    super(new ExpressAdapter(), options)
+  }
+}

--- a/packages/express/index.ts
+++ b/packages/express/index.ts
@@ -1,0 +1,2 @@
+export * from './express-broker'
+export * from './express-context'

--- a/packages/http/adapter/http-events.ts
+++ b/packages/http/adapter/http-events.ts
@@ -1,0 +1,68 @@
+import { EventChannel, EventType, type EventOptions } from '@glandjs/common';
+import { Callback, Noop } from '@medishn/toolkit';
+export class HttpEventCore implements EventChannel {
+  constructor(private readonly _channel: EventChannel) {}
+
+  respond<T, R>(listener: (data: T, respond: (result: R) => void) => void): Noop;
+  respond<T, R>(type: EventType, listener: (data: T, respond: (result: R) => void) => void): Noop;
+  respond(...args: any[]): Noop {
+    return this._channel.respond(...(args as [EventType, any]));
+  }
+
+  request<R>(type: EventType, data: any, strategy?: 'first' | 'last'): R | undefined;
+  request<R>(type: EventType, data: any, strategy?: 'all'): R[];
+  request<R>(type: any, data: any, strategy?: any): R | R[] | undefined {
+    return this._channel.request(type, data, strategy);
+  }
+
+  channel(type: EventType): HttpEventCore {
+    return new HttpEventCore(this._channel.channel(type));
+  }
+  emit<T>(type: EventType, data: T, options?: EventOptions): void;
+  emit<T>(data: T, options?: EventOptions): void;
+  emit(...args: any[]): void {
+    this._channel.emit(...(args as [any]));
+  }
+
+  getListeners<T>(event: EventType): T[];
+  getListeners<T>(): T[];
+  getListeners(...args: any[]): Callback<any>[] {
+    return this._channel.getListeners(...(args as [EventType]));
+  }
+
+  off<T extends any[] = any>(listener: Callback<T>): void;
+  off<T extends any[] = any>(event: EventType, listener: Callback<T>): void;
+  off(...args: any[]): void {
+    this._channel.off(...(args as [EventType, any]));
+  }
+
+  on<T extends any = any>(listener: Callback<[T]>, options?: EventOptions): Noop;
+  on<T extends any = any>(event: EventType, listener: Callback<[T]>, options?: EventOptions): Noop;
+  on(...args: any[]): Noop {
+    return this._channel.on(...(args as [any]));
+  }
+
+  once<T extends any = any>(listener: Callback<[T]>): void;
+  once<T extends any = any>(event: EventType, listener: Callback<[T]>): void;
+  once(...args: any[]): void {
+    return this._channel.once(...(args as [EventType, any]));
+  }
+
+  broadcast<T extends string, D>(data?: D): void;
+  broadcast<T extends string, D>(type: EventType, data?: D): void;
+  broadcast(...args: any[]): void {
+    return this._channel.broadcast(...(args as [EventType]));
+  }
+
+  safeEmit<T>(type: EventType, data: T): boolean {
+    this.emit(type, data, { queue: true });
+
+    const listeners = this.getListeners(type);
+
+    if (listeners.length === 0) {
+      this.off(type, () => {});
+      return false;
+    }
+    return true;
+  }
+}

--- a/packages/http/adapter/http.adapter.ts
+++ b/packages/http/adapter/http.adapter.ts
@@ -1,0 +1,43 @@
+import { Logger } from '@medishn/toolkit'
+import { HttpEventCore } from './http-events'
+import { Broker } from '@glandjs/events'
+import type { CorsConfig, RouteAction } from '../types'
+export abstract class HttpServerAdapter<TServer, TAapp, TRequest, TResponse> {
+  protected logger = new Logger({ context: 'HTTP:Adapter' })
+  public broker: Broker
+  public events: HttpEventCore
+  protected server: TServer
+  constructor(public instance: TAapp) {
+    this.broker = new Broker('http')
+    this.events = new HttpEventCore(this.broker.channel('http'))
+    this.events.on('options', this.initialize.bind(this))
+  }
+  public abstract initialize(): Promise<void> | void
+  public abstract listen(
+    port: string | number,
+    hostname?: string,
+    message?: string
+  ): void
+  public abstract close(): Promise<void>
+  public abstract use(...args: any): any
+  public abstract registerRoute(
+    method: string,
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): void
+
+  public abstract enableCors(options: CorsConfig): void
+
+  public abstract setGlobalPrefix(prefix: string): void
+
+  public abstract useStaticAssets(path: string, options?: any): void
+
+  public handleError(error: any, message: string) {
+    this.events.safeEmit('$server:crashed', {
+      message,
+      error,
+      stack: error.stack,
+    })
+    throw error
+  }
+}

--- a/packages/http/adapter/index.ts
+++ b/packages/http/adapter/index.ts
@@ -1,0 +1,2 @@
+export * from './http.adapter';
+export * from './http-events';

--- a/packages/http/context/http-context.ts
+++ b/packages/http/context/http-context.ts
@@ -1,0 +1,20 @@
+import { Context } from '@glandjs/core'
+import { HttpEventCore } from '../adapter/http-events'
+
+import type { Broker } from '@glandjs/events'
+
+/**
+ * HTTP-specific context providing access to request/response objects and utility methods.
+ * @example
+ * ctx.send('Hello World');
+ */
+export class HttpContext<TRequest, TResponse> extends Context {
+  constructor(
+    protected readonly events: HttpEventCore,
+    public readonly req: TRequest,
+    public readonly res: TResponse
+  ) {
+    const broker = events['_channel']['broker'] as Broker
+    super(broker)
+  }
+}

--- a/packages/http/context/index.ts
+++ b/packages/http/context/index.ts
@@ -1,0 +1,1 @@
+export * from './http-context';

--- a/packages/http/decorators/http.decorator.ts
+++ b/packages/http/decorators/http.decorator.ts
@@ -1,0 +1,107 @@
+import { METHOD_METADATA, PATH_METADATA } from '@glandjs/common'
+import { RequestMethod } from '../enum'
+
+export interface RequestMappingMetadata {
+  path?: string | string[]
+  method?: RequestMethod
+}
+
+const defaultMetadata = {
+  [PATH_METADATA]: '/',
+  [METHOD_METADATA]: RequestMethod.GET,
+}
+
+/**
+ * Base Request Mapping Decorator
+ */
+export const RequestMapping = (
+  metadata: RequestMappingMetadata = defaultMetadata
+): MethodDecorator => {
+  const pathMetadata = metadata[PATH_METADATA]
+  const path = pathMetadata && pathMetadata.length ? pathMetadata : '/'
+  const requestMethod = metadata[METHOD_METADATA] || RequestMethod.GET
+
+  return (
+    target: object,
+    key: string | symbol,
+    descriptor: TypedPropertyDescriptor<any>
+  ) => {
+    Reflect.defineMetadata(PATH_METADATA, path, descriptor.value)
+    Reflect.defineMetadata(METHOD_METADATA, requestMethod, descriptor.value)
+    return descriptor
+  }
+}
+/**
+ * Helper function to create HTTP Method Decorators
+ */
+const createMappingDecorator =
+  (method: RequestMethod) =>
+  (path?: string | string[]): MethodDecorator => {
+    return RequestMapping({
+      [PATH_METADATA]: path,
+      [METHOD_METADATA]: method,
+    })
+  }
+
+/**
+ * Route handler (method) Decorator. Routes HTTP POST requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Post = createMappingDecorator(RequestMethod.POST)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP GET requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Get = createMappingDecorator(RequestMethod.GET)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP DELETE requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Delete = createMappingDecorator(RequestMethod.DELETE)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP PUT requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Put = createMappingDecorator(RequestMethod.PUT)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP PATCH requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Patch = createMappingDecorator(RequestMethod.PATCH)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP OPTIONS requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Options = createMappingDecorator(RequestMethod.OPTIONS)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP HEAD requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Head = createMappingDecorator(RequestMethod.HEAD)
+
+/**
+ * Route handler (method) Decorator. Routes all HTTP requests to the specified path.
+ *
+ * @publicApi
+ */
+export const All = createMappingDecorator(RequestMethod.ALL)
+
+/**
+ * Route handler (method) Decorator. Routes HTTP SEARCH requests to the specified path.
+ *
+ * @publicApi
+ */
+export const Search = createMappingDecorator(RequestMethod.SEARCH)

--- a/packages/http/decorators/index.ts
+++ b/packages/http/decorators/index.ts
@@ -1,0 +1,2 @@
+import 'reflect-metadata';
+export * from './http.decorator';

--- a/packages/http/enum/index.ts
+++ b/packages/http/enum/index.ts
@@ -1,0 +1,1 @@
+export * from './method.enum';

--- a/packages/http/enum/method.enum.ts
+++ b/packages/http/enum/method.enum.ts
@@ -1,0 +1,11 @@
+export enum RequestMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+  PATCH = 'PATCH',
+  ALL = 'ALL',
+  OPTIONS = 'OPTIONS',
+  HEAD = 'HEAD',
+  SEARCH = 'SEARCH',
+}

--- a/packages/http/http-broker.ts
+++ b/packages/http/http-broker.ts
@@ -1,0 +1,25 @@
+import { BrokerAdapter } from '@glandjs/core'
+import type { RouteRegister } from '@glandjs/core/injector'
+import type { HttpCore } from './http-core'
+
+/**
+ * HttpBroker bridges HTTP-specific logic to the core Gland event system
+ */
+export class HttpBroker<
+  TApp extends HttpCore<any, any, any, any>,
+  TOptions,
+> extends BrokerAdapter<TApp, TOptions> {
+  constructor(instance: TApp, options?: TOptions) {
+    super(options)
+    this.instance = instance
+    this.broker = this.instance.broker
+  }
+
+  public initialize(): TApp {
+    this.broker.on<[RouteRegister]>('gland:router:register', (payload) => {
+      const { method, action, controller } = payload
+      this.instance[method.toLowerCase()](controller.path, action)
+    })
+    return this.instance
+  }
+}

--- a/packages/http/http-core.ts
+++ b/packages/http/http-core.ts
@@ -1,0 +1,166 @@
+import { Callback, Noop } from '@medishn/toolkit'
+import { EventType } from '@glandjs/common'
+import { HttpApplicationOptions } from './interface'
+import {
+  type ApplicationEventMap,
+  type ServerListening,
+} from './types/app-options.types'
+import { RequestMethod } from './enum'
+import type { HttpServerAdapter } from './adapter'
+import type { CorsConfig, RouteAction } from './types'
+import type { HttpEventType } from './http-events.const'
+
+/**
+ * The core HTTP server class for the Gland framework.
+ *
+ * `HttpCore` provides a fully event-driven HTTP/HTTPS server implementation
+ * @example
+ * ```typescript
+ * // Simple route handler
+ * app.get('/', (ctx) => {
+ *   ctx.send('Hello, Gland!');
+ * });
+ * // Middleware example
+ * app.use((ctx, next) => {
+ *   console.log('Request received:', ctx.path);
+ *   next();
+ * });
+ * ```
+ */
+export class HttpCore<TServer, TApp, TRequest, TResponse> {
+  constructor(
+    private readonly _adapter: HttpServerAdapter<
+      TServer,
+      TApp,
+      TRequest,
+      TResponse
+    >,
+    options?: HttpApplicationOptions
+  ) {
+    this.initializeEvents(options)
+  }
+  private initializeEvents(options?: HttpApplicationOptions) {
+    this._adapter.events.emit('options', options)
+  }
+  get broker() {
+    return this._adapter.broker
+  }
+
+  get id() {
+    return this.broker.id
+  }
+
+  get settings() {
+    return
+  }
+
+  public listen(port: number, args?: ServerListening) {
+    this._adapter.listen(port, args?.host, args?.message)
+  }
+
+  /**
+   * @example
+   * ```typescript
+   * // Gland-style middleware
+   * app.use((ctx, next) => {
+   *   console.log('Request:', ctx.method, ctx.path);
+   *   next();
+   * });
+   *
+   * // Express-style middleware
+   * app.use((req, res, next) => {
+   *   res.setHeader('X-Powered-By', 'Gland');
+   *   next();
+   * });
+   *
+   * // Path-specific middleware
+   * app.use('/api', (ctx, next) => {
+   *   ctx.state.apiRequest = true;
+   *   next();
+   * });
+   * ```
+   */
+  public use(...args: any[]): void {
+    this._adapter.use(...args)
+  }
+
+  private _registerRoute(
+    method: string,
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): this {
+    this._adapter.registerRoute(method, path, action)
+    return this
+  }
+
+  // HTTP Methods
+  public get = (path: string, action: RouteAction<TRequest, TResponse>): this =>
+    this._registerRoute(RequestMethod.GET, path, action)
+  public post = (
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): this => this._registerRoute(RequestMethod.POST, path, action)
+  public put = (path: string, action: RouteAction<TRequest, TResponse>): this =>
+    this._registerRoute(RequestMethod.PUT, path, action)
+  public delete = (
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): this => this._registerRoute(RequestMethod.DELETE, path, action)
+  public patch = (
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): this => this._registerRoute(RequestMethod.PATCH, path, action)
+  public head = (
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): this => this._registerRoute(RequestMethod.HEAD, path, action)
+  public options = (
+    path: string,
+    action: RouteAction<TRequest, TResponse>
+  ): this => this._registerRoute(RequestMethod.OPTIONS, path, action)
+  public all = (path: string, action: RouteAction<TRequest, TResponse>): this =>
+    this._registerRoute(RequestMethod.ALL, path, action)
+
+  public enableCors(options: CorsConfig) {
+    this._adapter.enableCors(options)
+  }
+  public useStaticAssets(path: string): void {
+    this._adapter.useStaticAssets(path)
+  }
+
+  // Event Management
+  public on<T>(event: HttpEventType, listener: Callback<[T]>): Noop {
+    const isExternal = this._adapter.events.getListeners(`external:${event}`)
+    if (isExternal) {
+      return this._adapter.events.on(`external:${event}`, listener)
+    } else {
+      return this._adapter.events.on(event, listener)
+    }
+  }
+  public emit<T>(type: EventType, data: T) {
+    this._adapter.events.emit(type, data)
+  }
+
+  public off<T>(event: HttpEventType, listener: Callback<[T]>): void {
+    this._adapter.events.off(event, listener)
+  }
+
+  public system<K extends keyof ApplicationEventMap<TRequest, TResponse>>(
+    event: K,
+    listener: ApplicationEventMap<TRequest, TResponse>[K]
+  ): void {
+    switch (event) {
+      case 'crashed':
+        this._adapter.events.on('$server:crashed', listener)
+        break
+      case 'router:miss':
+        this._adapter.events.on('$router:miss', listener)
+        break
+      case 'request:failed':
+        this._adapter.events.on('$request:failed', listener)
+        break
+      default:
+        throw Error(`Unknown system event: ${event}`)
+    }
+  }
+}

--- a/packages/http/http-events.const.ts
+++ b/packages/http/http-events.const.ts
@@ -1,0 +1,42 @@
+export const HTTP_EVENTS = {
+  ROUTER: `router`,
+  PIPELINE: `pipeline`,
+  MIDDLEWARE: `middleware`,
+}
+
+export const RouterEvent = {
+  MATCH: `${HTTP_EVENTS.ROUTER}:match`,
+  ROUTER_REGISTER: `${HTTP_EVENTS.ROUTER}:register`,
+}
+
+export type RouterEventType = keyof typeof RouterEvent
+
+export const PipelineEvent = {
+  PIPELINE_EXECUTE: `${HTTP_EVENTS.PIPELINE}:execute`,
+  PIPELINE_REGISTER: `${HTTP_EVENTS.PIPELINE}:register`,
+}
+
+export type PipelineEventType = keyof typeof PipelineEvent
+
+export const MiddlewareEvent = {
+  MIDDLEWARE_REGISTER: `${HTTP_EVENTS.MIDDLEWARE}:register`,
+  MIDDLEWARE_EXECUTE: `${HTTP_EVENTS.MIDDLEWARE}:execute`,
+  GLOBAL: `${HTTP_EVENTS.MIDDLEWARE}:global`,
+  RESOLVER: `${HTTP_EVENTS.MIDDLEWARE}:resolve`,
+  FOR_ROUTE: `${HTTP_EVENTS.MIDDLEWARE}:route-specific`,
+  MOUNT: `${HTTP_EVENTS.MIDDLEWARE}:mount`,
+  APPLY_GLOBAL: `${HTTP_EVENTS.MIDDLEWARE}:apply-global`,
+  USE: `${HTTP_EVENTS.MIDDLEWARE}:use`,
+}
+
+export type MiddlewareEventType = keyof typeof MiddlewareEvent
+export type AllHttpEvents =
+  | MiddlewareEventType
+  | PipelineEventType
+  | RouterEventType
+type HttpEventMap = {
+  [M in AllHttpEvents]: M | `${M}` | AllHttpEvents
+}
+export type HttpEventType<T extends string = string> =
+  | `${HttpEventMap[keyof HttpEventMap]}`
+  | T

--- a/packages/http/index.ts
+++ b/packages/http/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Gland HTTP Module
+ * Copyright(c) 2024 - 2025 Mahdi
+ * MIT Licensed
+ *
+ *
+ * The `@glandjs/http` package provides a fully event-driven HTTP/HTTPS server based on the Gland framework.
+ * It is designed to work seamlessly with `@glandjs/core`, leveraging the Event-Driven System (EDS)
+ *
+ * @example
+ * ```ts
+ * import { HttpCore } from '@glandjs/http';
+ * const app = new HttpCore();
+ *
+ * app.get('/', (ctx) => {
+ *   ctx.send('Hello, Gland!');
+ * });
+ *
+ * app.listen(3000);
+ * ```
+ * @since 1.0.0
+ */
+export * from './http-core'
+export * from './http-broker'
+export * from './decorators'
+export * from './enum'
+export * from './server'
+export * from './context'
+export * from './adapter'
+export * from './interface'

--- a/packages/http/interface/app-options.interface.ts
+++ b/packages/http/interface/app-options.interface.ts
@@ -1,0 +1,8 @@
+import { HttpsOptions } from './http-options.interface'
+
+export interface HttpApplicationOptions {
+  /**
+   * HTTPS configuration.
+   */
+  https?: HttpsOptions
+}

--- a/packages/http/interface/cors-options.interface.ts
+++ b/packages/http/interface/cors-options.interface.ts
@@ -1,0 +1,56 @@
+import type { RequestMethod } from '../enum'
+import type { CustomOrigin, StaticOrigin } from '../types'
+
+export interface CorsOptionsCallback {
+  (error: Error | null, options: CorsOptions): void
+}
+export interface CorsOptionsDelegate<T> {
+  (req: T, cb: CorsOptionsCallback): void
+}
+
+export interface CorsOptions {
+  /**
+   * Configures the `Access-Control-Allow-Origin` CORS header.
+   * @default '*'
+   */
+  origin?: StaticOrigin | CustomOrigin
+
+  /**
+   * Configures the `Access-Control-Allow-Methods` CORS header.
+   * @default 'GET,HEAD,PUT,PATCH,POST,DELETE'
+   */
+  methods?: keyof typeof RequestMethod | (keyof typeof RequestMethod)[]
+
+  /**
+   * Configures the `Access-Control-Allow-Headers` CORS header.
+   */
+  allowedHeaders?: string | string[]
+
+  /**
+   * Configures the `Access-Control-Expose-Headers` CORS header.
+   */
+  exposedHeaders?: string | string[]
+
+  /**
+   * Configures the `Access-Control-Allow-Credentials` CORS header.
+   * @default false
+   */
+  credentials?: boolean
+
+  /**
+   * Configures the `Access-Control-Max-Age` CORS header.
+   */
+  maxAge?: number
+
+  /**
+   * Whether to pass the CORS preflight response to the next handler.
+   * @default false
+   */
+  preflightContinue?: boolean
+
+  /**
+   * Provides a status code to use for successful `OPTIONS` requests.
+   * @default 204
+   */
+  optionsSuccessStatus?: number
+}

--- a/packages/http/interface/http-options.interface.ts
+++ b/packages/http/interface/http-options.interface.ts
@@ -1,0 +1,26 @@
+export interface HttpsOptions {
+  pfx?: any
+
+  key?: any
+  passphrase?: string
+
+  cert?: any
+
+  ca?: any
+
+  crl?: any
+
+  ciphers?: string
+
+  honorCipherOrder?: boolean
+
+  requestCert?: boolean
+
+  rejectUnauthorized?: boolean
+
+  NPNProtocols?: any
+
+  SNICallback?: (servername: string, cb: (err: Error, ctx: any) => any) => any
+
+  secureOptions?: number
+}

--- a/packages/http/interface/index.ts
+++ b/packages/http/interface/index.ts
@@ -1,0 +1,4 @@
+export * from './app-options.interface'
+export * from './http-options.interface'
+export * from './cors-options.interface'
+export * from './next-function.interface'

--- a/packages/http/interface/next-function.interface.ts
+++ b/packages/http/interface/next-function.interface.ts
@@ -1,0 +1,1 @@
+export type NextFunction = () => Promise<void>;

--- a/packages/http/server/index.ts
+++ b/packages/http/server/index.ts
@@ -1,0 +1,1 @@
+export * from './server-factory'

--- a/packages/http/server/server-factory.ts
+++ b/packages/http/server/server-factory.ts
@@ -1,0 +1,23 @@
+import { Logger } from '@medishn/toolkit'
+import { Server } from 'net'
+import { HttpApplicationOptions } from '../interface'
+import type { RequestListener } from 'http'
+export class ServerFactory {
+  private static readonly _logger = new Logger({ context: 'HTTP:Server' })
+
+  public static create(
+    options?: HttpApplicationOptions,
+    listener?: RequestListener
+  ): Server {
+    const isHttpsEnabled = options?.https
+    this._logger.info(
+      `Initializing ${isHttpsEnabled ? 'HTTPS' : 'HTTP'} server...`
+    )
+    const serverModule = isHttpsEnabled ? require('https') : require('http')
+
+    if (isHttpsEnabled) {
+      return serverModule.createServer(options!.https)
+    }
+    return serverModule.createServer(listener)
+  }
+}

--- a/packages/http/types/app-options.types.ts
+++ b/packages/http/types/app-options.types.ts
@@ -1,0 +1,22 @@
+import type { HttpContext } from '../context'
+
+export type ServerListening = {
+  host?: string
+  message?: string
+}
+export type ServerCrashedEvent = {
+  message: string
+  error: Error
+  stack: string
+  timestamp: string
+}
+
+export type ServerListenerCallback = (error: ServerCrashedEvent) => void
+export type ApplicationEventMap<TRequest, TResponse> = {
+  crashed: ServerListenerCallback
+  'router:miss': (ctx: HttpContext<TRequest, TResponse>) => Promise<void> | void
+  'request:failed': (
+    error: any,
+    ctx: HttpContext<TRequest, TResponse>
+  ) => Promise<void> | void
+}

--- a/packages/http/types/cors-options.types.ts
+++ b/packages/http/types/cors-options.types.ts
@@ -1,0 +1,14 @@
+import { Maybe } from '@medishn/toolkit'
+import type { CorsOptions, CorsOptionsDelegate } from '../interface'
+import type { IncomingMessage } from 'http'
+export type StaticOrigin = boolean | string | RegExp | (string | RegExp)[]
+
+export type CustomOrigin = (
+  requestOrigin: string,
+  callback: (err: Maybe<Error>, origin?: StaticOrigin) => void
+) => void
+
+export type CorsConfig =
+  | boolean
+  | CorsOptions
+  | CorsOptionsDelegate<IncomingMessage>

--- a/packages/http/types/index.ts
+++ b/packages/http/types/index.ts
@@ -1,0 +1,3 @@
+export * from './app-options.types'
+export * from './cors-options.types'
+export * from './route-action.type'

--- a/packages/http/types/route-action.type.ts
+++ b/packages/http/types/route-action.type.ts
@@ -1,0 +1,5 @@
+import type { HttpContext } from '../context'
+
+export type RouteAction<TRequest, TResponse> = (
+  ctx: HttpContext<TRequest, TResponse>
+) => any | Promise<any>

--- a/packages/http/utils/index.ts
+++ b/packages/http/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './sse-stream'

--- a/packages/http/utils/sse-stream.ts
+++ b/packages/http/utils/sse-stream.ts
@@ -1,0 +1,2 @@
+// This feature is not currently implemented, and this class is not fully implemented.
+export class SSEStream {}


### PR DESCRIPTION
This PR introduces a major structural improvement to the `@glandjs/http` package by implementing a flexible and extensible **HTTP Adapter Architecture**. The new design decouples the core HTTP logic from the underlying server implementation (e.g., Express, Fastify, native HTTP), enabling seamless integration with various HTTP engines and connection to `@glandjs/core`.

#### What's New?

##### `@glandjs/http`:
- Restructured into an **adapter-pattern-based architecture**.
- Introduced the `HttpServerAdapter` base class that defines a unified interface (`listen`, `use`, `registerRoute`, etc.) for all HTTP engines.
- All HTTP implementations (like Express/Fastify) must now implement this interface.
- The `HttpCore` now acts as a **client** that connects to any conforming adapter, and is responsible for handling DI, lifecycle events, and internal messaging.
- Event-based lifecycle hooks like `'options'`, `'ready'`, `'close'` are still preserved and fully functional.

##### `@glandjs/express`:
- Added a fully functional `ExpressAdapter` that implements `HttpServerAdapter` and serves as a plug-and-play module for Express apps.
- Supports full integration with `@glandjs/core` via the `connectTo()` method.
- Enables easy route declaration using decorators like `@Get()`, `@Post()`, etc. alongside dependency-injected `Controllers`.
- Supports middleware, CORS, view engines, static assets, and global prefixes through a clean adapter-based abstraction.

---

### Example:

```ts
import { Controller, Module } from '@glandjs/common'
import { Get } from '@glandjs/http'
import { GlandFactory } from '@glandjs/core'
import { ExpressBroker, type ExpressContext } from '@glandjs/express'

@Controller('/')
class UserController {
  @Get()
  index(ctx: ExpressContext) {
    ctx.res.send('Hello World')
  }
}

@Module({
  controllers: [UserController],
})
class AppModule {}

async function bootstrap() {
  const app = await GlandFactory.create(AppModule)
  const express = app.connectTo(ExpressBroker)
  express.listen(3000)
}
bootstrap()
```
